### PR TITLE
Fix compile error when without ecto deps

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -908,7 +908,7 @@ defmodule Uniq.UUID do
   ## Ecto
 
   if Code.ensure_loaded?(Ecto.Type) do
-    use Ecto.Type
+    @behaviour Ecto.Type
 
     @doc false
     @impl Ecto.Type


### PR DESCRIPTION
Hello,

When use `uniq` without the `ecto` dependency, it will see the following error:

```
==> uniq
Compiling 4 files (.ex)

== Compilation error in file lib/uuid.ex ==
** (CompileError) lib/uuid.ex:913: module Ecto.Type is not loaded and could not be found
    (elixir 1.12.1) expanding macro: Kernel.use/1
    lib/uuid.ex:913: Uniq.UUID (module)
    (elixir 1.12.1) expanding macro: Kernel.if/2
    lib/uuid.ex:910: Uniq.UUID (module)
```

This PR is to fix this issue, please review.

Thanks