### PR TITLE
fix: make ecto deps optional

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Uniq.MixProject do
   def project do
     [
       app: :uniq,
-      version: "0.4.2",
+      version: "0.4.3",
       elixir: "~> 1.11",
       description: description(),
       package: package(),
@@ -88,7 +88,7 @@ defmodule Uniq.MixProject do
   defp deps do
     [
       {:benchee, "~> 1.0", only: [:bench]},
-      {:ecto, "~> 3.0"},
+      {:ecto, "~> 3.0", optional: true},
       {:ex_doc, "> 0.0.0", only: [:docs], runtime: false},
       {:elixir_uuid, "> 0.0.0", only: [:bench]},
       {:stream_data, "~> 0.5", only: [:test]}


### PR DESCRIPTION
Hey @bitwalker,

I noticed that ecto kept being added to my `mix.lock` even when I didn't have an Ecto project. Maybe it would be prudent to mark the dependency as optional.