### PR TITLE
Add UUID v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ be found on Hex as `:uniq`.
 ## Features
 
 * Follows the RFC 4122 specification, i.e. supports UUID versions 1, 3, 4, and 5 as described in the RFC
-* Supports UUIDv6, which is described in a proposed extension for RFC 4122, and improves upon desirable traits 
+* Supports UUIDv6 and UUIDv7, which are described in a proposed extension for RFC 4122, and improve upon desirable traits 
 of both UUIDv1 and UUIDv4 to provide the best of both, while removing their downsides.  See 
 [here](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format) for more information on how it does so.
 * Supports formatting UUIDs as canonical strings (e.g. `6ba7b810-9dad-11d1-80b4-00c04fd430c8`, with or without the dashes),

--- a/test/ecto_test.exs
+++ b/test/ecto_test.exs
@@ -34,6 +34,16 @@ defmodule Uniq.Ecto.Test do
     end
   end
 
+  defmodule Person.Version7 do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "person_v7" do
+      field(:id, Uniq.UUID, version: 7, autogenerate: true)
+      field(:name, :string)
+    end
+  end
+
   test "can autogenerate primary keys" do
     assert %Person.Version4{id: uuid} =
              Ecto.Changeset.cast(%Person.Version4{}, %{name: "Paul"}, [:name])
@@ -52,5 +62,11 @@ defmodule Uniq.Ecto.Test do
              |> TestRepo.insert!()
 
     assert {:ok, %UUID{version: 6}} = UUID.parse(uuid)
+
+    assert %Person.Version7{id: uuid} =
+             Ecto.Changeset.cast(%Person.Version7{}, %{name: "Paul"}, [:name])
+             |> TestRepo.insert!()
+
+    assert {:ok, %UUID{version: 7}} = UUID.parse(uuid)
   end
 end

--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -9,7 +9,7 @@ defmodule Uniq.Test.Generators do
   @reserved_ms <<6::3>>
   @reserved_future <<7::3>>
   @rfc_versions [1, 3, 4, 5]
-  @versions [1, 3, 4, 5, 6]
+  @versions [1, 3, 4, 5, 6, 7]
   @variants [@reserved_ncs, @rfc_variant, @reserved_ms, @reserved_future]
   @reserved_variants [@reserved_ncs, @reserved_ms, @reserved_future]
   @reserved_variants_uniform [<<0::3>>, <<6::3>>, <<7::3>>]
@@ -48,7 +48,7 @@ defmodule Uniq.Test.Generators do
             bind(bitstring(length: 128), fn <<start::48, v::4, mid::12, var::bitstring-size(3),
                                               rest::61>> = bits ->
               case v do
-                6 ->
+                v when v in [6, 7] ->
                   # Version 6 specifically only allows a single variant to be considered valid
                   case var do
                     <<@rfc_variant, _::1>> ->
@@ -65,7 +65,7 @@ defmodule Uniq.Test.Generators do
                 v when v in @rfc_versions ->
                   # Any 3-bit pattern is technically valid as a variant in a UUID per the RFC, so we instead generate
                   # a known-invalid version.
-                  bind(integer(7..15), fn version ->
+                  bind(integer(8..15), fn version ->
                     constant(<<start::48, version::4, mid::12, var::bitstring-size(3), rest::61>>)
                   end)
 

--- a/test/uniq_test.exs
+++ b/test/uniq_test.exs
@@ -16,7 +16,8 @@ defmodule Uniq.Test do
       4 => "e5a4a3c3-45a7-4d5a-9809-e253a6ff8da2",
       # generated in the :dns namespace, name "test"
       5 => "4be0643f-1d98-573b-97cd-ca98a65347dd",
-      6 => "1e7126af-f130-6780-adb4-8bbe7368fc2f"
+      6 => "1e7126af-f130-6780-adb4-8bbe7368fc2f",
+      7 => "0182b66c-29e7-7ae8-b60e-4b669fe07c77"
     }
 
     hex =
@@ -61,6 +62,10 @@ defmodule Uniq.Test do
 
     test "can parse version 6", %{uuids: uuids} do
       assert parse(6, uuids)
+    end
+
+    test "can parse version 7", %{uuids: uuids} do
+      assert parse(7, uuids)
     end
 
     property "can parse any 128-bit binary with valid version/variant values" do
@@ -124,6 +129,10 @@ defmodule Uniq.Test do
     test "can format version 6", %{uuids: uuids} do
       assert format(6, uuids)
     end
+
+    test "can format version 7", %{uuids: uuids} do
+      assert format(7, uuids)
+    end
   end
 
   describe "generating" do
@@ -183,6 +192,14 @@ defmodule Uniq.Test do
 
       assert {:ok, %UUID{format: :default, version: 6}} = UUID.parse(default)
       assert {:ok, %UUID{format: :raw, version: 6}} = UUID.parse(raw)
+    end
+
+    test "can generate version 7" do
+      default = UUID.uuid7()
+      raw = UUID.uuid7(:raw)
+
+      assert {:ok, %UUID{format: :default, version: 7}} = UUID.parse(default)
+      assert {:ok, %UUID{format: :raw, version: 7}} = UUID.parse(raw)
     end
   end
 


### PR DESCRIPTION
The RFC 4122 Draft extension has added v7 and v8, and I'm wondering if you are interested in adding v7 support?

https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04#section-5.2