### PR TITLE
Use the SPDX Identifier for the package license

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -103,7 +103,7 @@ defmodule Uniq.MixProject do
     [
       files: ["lib", "mix.exs", "README.md", "LICENSE.md"],
       maintainers: ["Paul Schoenfelder"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{
         GitHub: "https://github.com/bitwalker/uniq"
       }


### PR DESCRIPTION
This is not a requirement of any system, it just makes it easier for certain tools (like hex_licenses) to find the exact license.