### PR TITLE
fix: elixir 1.14 warnings

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -4,8 +4,7 @@ defmodule Uniq.UUID do
 
   See the [README](README.md) for general usage information.
   """
-  use Bitwise, skip_operators: true
-
+  import Bitwise, except: [~~~: 1, &&&: 2, |||: 2, ^^^: 2, <<<: 2, >>>: 2]
   import Kernel, except: [to_string: 1]
 
   defstruct [:format, :version, :variant, :time, :seq, :node, :bytes]


### PR DESCRIPTION
Replaces the deprecated `use Bitwise` with the equivalent `import Bitwise`.