### PR TITLE
chore: elixir 1.14 and otp 25.1

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['24.3', '25.0']
-        elixir: ['1.12.3', '1.13.4']
+        otp: ['24.3', '25.1']
+        elixir: ['1.12.3', '1.13.4', '1.14']
         exclude:
-        - otp: '25.0'
+        - otp: '25.1'
           elixir: '1.12.3'
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Bump OTP and include the latest Elixir.

Thanks @bitwalker for the high-quality library and the fantastic docs!