### PR TITLE
Add many_to_many example

### DIFF
--- a/guides/using_with_ecto.md
+++ b/guides/using_with_ecto.md
@@ -68,7 +68,7 @@ defmodule MyApp.Comment do
 end
 ```
 
-For many_to_many association you should add **type: :uuid**:
+For many_to_many association you should add `type: :uuid`:
 
 ```elixir
 @primary_key {:id, Uniq.UUID, version: 7, autogenerate: true, type: :uuid}


### PR DESCRIPTION
When i try to use many_to_many associations i have this error: 

** (Postgrex.Error) ERROR 42846 (cannot_coerce) cannot cast type uuid to bytea

After 10-15 minutes i found closed PR - https://github.com/bitwalker/uniq/issues/10

I suggest adding an example for setting up many_to_many association so that people don't look for a solution on the Internet.
