### PR TITLE
Generic uuidv8 parsing support (version, variant, bytes)

### DIFF
--- a/test/support/generators.ex
+++ b/test/support/generators.ex
@@ -9,7 +9,7 @@ defmodule Uniq.Test.Generators do
   @reserved_ms <<6::3>>
   @reserved_future <<7::3>>
   @rfc_versions [1, 3, 4, 5]
-  @versions [1, 3, 4, 5, 6, 7]
+  @versions [1, 3, 4, 5, 6, 7, 8]
   @variants [@reserved_ncs, @rfc_variant, @reserved_ms, @reserved_future]
   @reserved_variants [@reserved_ncs, @reserved_ms, @reserved_future]
   @reserved_variants_uniform [<<0::3>>, <<6::3>>, <<7::3>>]
@@ -48,7 +48,7 @@ defmodule Uniq.Test.Generators do
             bind(bitstring(length: 128), fn <<start::48, v::4, mid::12, var::bitstring-size(3),
                                               rest::61>> = bits ->
               case v do
-                v when v in [6, 7] ->
+                v when v in [6, 7, 8] ->
                   # Version 6 specifically only allows a single variant to be considered valid
                   case var do
                     <<@rfc_variant, _::1>> ->
@@ -65,7 +65,7 @@ defmodule Uniq.Test.Generators do
                 v when v in @rfc_versions ->
                   # Any 3-bit pattern is technically valid as a variant in a UUID per the RFC, so we instead generate
                   # a known-invalid version.
-                  bind(integer(8..15), fn version ->
+                  bind(integer(9..15), fn version ->
                     constant(<<start::48, version::4, mid::12, var::bitstring-size(3), rest::61>>)
                   end)
 

--- a/test/uniq_test.exs
+++ b/test/uniq_test.exs
@@ -17,7 +17,8 @@ defmodule Uniq.Test do
       # generated in the :dns namespace, name "test"
       5 => "4be0643f-1d98-573b-97cd-ca98a65347dd",
       6 => "1e7126af-f130-6780-adb4-8bbe7368fc2f",
-      7 => "0182b66c-29e7-7ae8-b60e-4b669fe07c77"
+      7 => "0182b66c-29e7-7ae8-b60e-4b669fe07c77",
+      8 => "34e3992d-8a73-83de-9486-0f622063b665"
     }
 
     hex =
@@ -66,6 +67,10 @@ defmodule Uniq.Test do
 
     test "can parse version 7", %{uuids: uuids} do
       assert parse(7, uuids)
+    end
+
+    test "can parse version 8", %{uuids: uuids} do
+      assert parse(8, uuids)
     end
 
     property "can parse any 128-bit binary with valid version/variant values" do

--- a/test/uniq_test.exs
+++ b/test/uniq_test.exs
@@ -138,6 +138,10 @@ defmodule Uniq.Test do
     test "can format version 7", %{uuids: uuids} do
       assert format(7, uuids)
     end
+
+    test "can format version 8", %{uuids: uuids} do
+      assert format(8, uuids)
+    end
   end
 
   describe "generating" do


### PR DESCRIPTION
We are using custom generated uuids v8 in some parts of our project, and we need to parse\validate uuids in general. Depending on a uuid version we use different code paths (uuid v8 are used in a few very specific cases).

We were using `elixir_uuid` and recently decided to switch to `uniq`. But currently it doesn't support uuid v8 parsing, so this is the implementation.