### PR TITLE
Fix random mac address generation for uuid1

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -824,13 +824,17 @@ defmodule Uniq.UUID do
          {_if, info} <- Enum.find(interfaces, candidate_interface?) do
       IO.iodata_to_binary(info[:hwaddr])
     else
-      _ ->
-        # In lieu of a MAC address, we can generate an equivalent number of random bytes
-        <<head::7, _::1, tail::46>> = :crypto.strong_rand_bytes(6)
-        # Ensure the multicast bit is set, as per RFC 4122
-        <<head::7, 1::1, tail::46>>
+      _ -> random_mac_address()
     end
   end
+
+  def random_mac_address do
+    # In lieu of a MAC address, we can generate an equivalent number of random bytes
+    <<head::7, _::1, tail::40>> = :crypto.strong_rand_bytes(6)
+    # Ensure the multicast bit is set, as per RFC 4122
+    <<head::7, 1::1, tail::40>>
+  end
+
 
   defp hash(:md5, data), do: :crypto.hash(:md5, data)
   defp hash(:sha, data), do: :binary.part(:crypto.hash(:sha, data), 0, 16)

--- a/test/uniq_test.exs
+++ b/test/uniq_test.exs
@@ -144,6 +144,16 @@ defmodule Uniq.Test do
       assert {:ok, %UUID{format: :raw, version: 1}} = UUID.parse(raw)
     end
 
+    test "can generate version 1 with random mac address" do
+      {_, clock} = Uniq.Generator.next()
+      node = UUID.random_mac_address()
+      default = UUID.uuid1(clock, node, :default)
+      raw = UUID.uuid1(clock, node, :raw)
+
+      assert {:ok, %UUID{format: :default, version: 1}} = UUID.parse(default)
+      assert {:ok, %UUID{format: :raw, version: 1}} = UUID.parse(raw)
+    end
+
     test "can generate version 3", %{uuids: uuids} do
       namespace = <<0::128>>
       name = "test"


### PR DESCRIPTION
The UUIDv1 generation on systems without proper network interfaces fails due to a miscounted match operator, 6 random bytes matched to 7 + 1 + 46 (54) bits, in the random mac address generation.

Also adds a test for random mac address generation.