### PR TITLE
Improve equality performance

### DIFF
--- a/bench/equality.exs
+++ b/bench/equality.exs
@@ -1,0 +1,17 @@
+uuid_string_4a = "db149e97-e4ef-4721-8ee5-93f6a30fdb29"
+uuid_string_4b = "b5f534f5-b76e-4667-b1d9-905fe8caef3f"
+uuid_string_7a = "019b3755-9921-7aea-a85f-ff750b527fc3"
+uuid_string_7b = "019b3755-9bfc-7d2e-8736-d734afa19f99"
+
+uuid_binary_1 = <<1, 155, 55, 87, 4, 95, 116, 181, 191, 179, 47, 102, 228, 223, 130, 13>>
+uuid_binary_2 = <<1, 155, 55, 87, 20, 249, 115, 209, 166, 166, 64, 143, 155, 51, 155, 131>>
+
+Benchee.run(
+  %{
+    "same v4 strings" => fn -> Uniq.UUID.equal?(uuid_string_4a, uuid_string_4a, nil) end,
+    "different v4 strings" => fn -> Uniq.UUID.equal?(uuid_string_4a, uuid_string_4b, nil) end,
+    "v4 vs v7 strings" => fn -> Uniq.UUID.equal?(uuid_string_4a, uuid_string_7a, nil) end,
+    "same v7 binaries" => fn -> Uniq.UUID.equal?(uuid_binary_1, uuid_binary_1, nil) end,
+    "different v7 binaries" => fn -> Uniq.UUID.equal?(uuid_binary_1, uuid_binary_1, nil) end,
+  }
+)

--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -739,11 +739,11 @@ defmodule Uniq.UUID do
 
   defp do_compare(a, b) do
     cond do
-      a < b ->
-        :lt
-
       a == b ->
         :eq
+
+      a < b ->
+        :lt
 
       :else ->
         :gt

--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -731,8 +731,8 @@ defmodule Uniq.UUID do
     do: do_compare(a, b)
 
   def compare(a, b) when is_binary(a) and is_binary(b) do
-    a = to_string(a)
-    b = to_string(b)
+    a = string_to_binary!(a)
+    b = string_to_binary!(b)
 
     do_compare(a, b)
   end

--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -1122,7 +1122,7 @@ defmodule Uniq.UUID do
     def equal?(nil, nil, _), do: true
     def equal?(nil, b, _), do: to_string(b, :raw) == @nil_id
     def equal?(a, nil, _), do: to_string(a, :raw) == @nil_id
-    def equal?(a, b, _), do: compare(to_string(a), to_string(b)) == :eq
+    def equal?(a, b, _), do: compare(a, b) == :eq
   end
 
   defimpl String.Chars do


### PR DESCRIPTION
This PR improves the performance of `equal?` as well as, to a lesser extent, `compare` itself.

The included benchmark gives the following results (run multiple times):

## Baseline

Name                            ips        average  deviation         median         99th %
different v7 binaries      642.26 K        1.56 μs   ±841.86%        1.11 μs        2.40 μs
same v7 binaries           622.83 K        1.61 μs   ±844.90%        1.12 μs        2.76 μs
same v4 strings            379.99 K        2.63 μs   ±683.27%        1.84 μs        4.62 μs
different v4 strings       375.33 K        2.66 μs   ±684.29%        1.88 μs        4.64 μs
v4 vs v7 strings           371.86 K        2.69 μs   ±639.47%        1.89 μs        4.70 μs


## Avoid to_string ( a9ef5651a3d8becc35ec41091a02ae8feccc61a2 )

Name                            ips        average  deviation         median         99th %
same v7 binaries          5885.31 K       0.170 μs  ±3018.94%       0.140 μs       0.166 μs
different v7 binaries     5858.78 K       0.171 μs  ±3048.43%       0.140 μs       0.165 μs
same v4 strings            841.61 K        1.19 μs   ±780.94%        0.96 μs        2.10 μs
v4 vs v7 strings           831.77 K        1.20 μs   ±785.29%        0.98 μs        2.04 μs
different v4 strings       827.27 K        1.21 μs   ±828.61%        0.96 μs        1.90 μs


## ... and reorder do_compare ( a733e78f24285df524a417ba84dcf17e31f8d6d8 )

Name                            ips        average  deviation         median         99th %
same v7 binaries          6494.76 K       0.154 μs  ±3087.36%       0.125 μs       0.156 μs
different v7 binaries     6431.47 K       0.155 μs  ±3366.79%       0.125 μs       0.157 μs
same v4 strings            834.00 K        1.20 μs   ±767.37%        0.95 μs        2.14 μs
different v4 strings       806.96 K        1.24 μs   ±792.53%        0.98 μs        2.17 μs
v4 vs v7 strings           804.18 K        1.24 μs   ±752.88%        0.98 μs        2.19 μs

## .. and use string_to_binary! when both are strings (084e1b68df9f50d93f18f355a098640a75410ffc )

Name                            ips        average  deviation         median         99th %
same v7 binaries          6533.71 K       0.153 μs  ±3268.81%       0.124 μs       0.151 μs
different v7 binaries     6517.77 K       0.153 μs  ±3215.38%       0.125 μs       0.149 μs
same v4 strings            854.34 K        1.17 μs  ±1217.72%        0.77 μs        2.04 μs
different v4 strings       851.66 K        1.17 μs  ±1219.59%        0.78 μs        2.01 μs
v4 vs v7 strings           840.23 K        1.19 μs  ±1266.56%

## Results

Reordering do_compare gives a c.a. 10% boost for binaries, but is a wash for strings. Using `string_to_binary!` as with all other `compare` code paths does give binary<->binary comparisons a small boost (c.a. 2%).

The biggest jump, by far, was simply avoiding `to_string` in `equal?` seeing as how `compare` does that for us anyways.  For binaries it's c.a. an order of magnitude faster, and roughly doubles the performance for strings.
