### PR TITLE
Scoped UUIDs

### DIFF
--- a/lib/scoped_uuid.ex
+++ b/lib/scoped_uuid.ex
@@ -1,4 +1,6 @@
 defmodule Uniq.ScopedUUID do
+  import Uniq.Macros, only: [defextension: 2]
+
   @doc """
   Generates and validates UUIDs in Ecto schemas which are scoped using a prefix.
 
@@ -35,116 +37,119 @@ defmodule Uniq.ScopedUUID do
       end
 
   """
-  use Ecto.ParameterizedType
 
-  @impl true
-  def init(opts) do
-    schema = Keyword.fetch!(opts, :schema)
-    field = Keyword.fetch!(opts, :field)
-    version = Keyword.get(opts, :uuid_version, 7)
+  defextension Ecto.ParameterizedType do
+    use Ecto.ParameterizedType
 
-    uuid_config =
-      Uniq.UUID.init(
-        schema: schema,
-        field: field,
-        version: version,
-        format: :slug,
-        default: :raw,
-        dump: :raw
-      )
+    @impl true
+    def init(opts) do
+      schema = Keyword.fetch!(opts, :schema)
+      field = Keyword.fetch!(opts, :field)
+      version = Keyword.get(opts, :uuid_version, 7)
 
-    foreign_key? = Keyword.get(opts, :foreign_key) != nil
+      uuid_config =
+        Uniq.UUID.init(
+          schema: schema,
+          field: field,
+          version: version,
+          format: :slug,
+          default: :raw,
+          dump: :raw
+        )
 
-    if foreign_key? do
-      %{
-        schema: schema,
-        field: field,
-        uuid_config: uuid_config
-      }
-    else
-      scope = Keyword.get(opts, :scope) || raise "`:scope` option is required"
+      foreign_key? = Keyword.get(opts, :foreign_key) != nil
 
-      if String.contains?(scope, "_") do
-        raise "ScopedUUID scopes may not contain underscores."
+      if foreign_key? do
+        %{
+          schema: schema,
+          field: field,
+          uuid_config: uuid_config
+        }
+      else
+        scope = Keyword.get(opts, :scope) || raise "`:scope` option is required"
+
+        if String.contains?(scope, "_") do
+          raise "ScopedUUID scopes may not contain underscores."
+        end
+
+        %{
+          scope: scope,
+          uuid_config: uuid_config
+        }
       end
-
-      %{
-        scope: scope,
-        uuid_config: uuid_config
-      }
     end
-  end
 
-  @impl true
-  def type(_params), do: :uuid
+    @impl true
+    def type(_params), do: :uuid
 
-  @impl true
-  def cast(nil, _params), do: {:ok, nil}
+    @impl true
+    def cast(nil, _params), do: {:ok, nil}
 
-  def cast(data, params) do
-    scope = scope_for(params)
+    def cast(data, params) do
+      scope = scope_for(params)
 
-    case extract_uuid(data, params) do
-      {:ok, ^scope, _uuid} -> {:ok, data}
-      _error -> :error
+      case extract_uuid(data, params) do
+        {:ok, ^scope, _uuid} -> {:ok, data}
+        _error -> :error
+      end
     end
-  end
 
-  @impl true
-  def load(data, loader, params) do
-    case Uniq.UUID.load(data, loader, params.uuid_config) do
-      {:ok, nil} -> {:ok, nil}
-      {:ok, uuid} -> {:ok, add_scope(uuid, params)}
-      :error -> :error
+    @impl true
+    def load(data, loader, params) do
+      case Uniq.UUID.load(data, loader, params.uuid_config) do
+        {:ok, nil} -> {:ok, nil}
+        {:ok, uuid} -> {:ok, add_scope(uuid, params)}
+        :error -> :error
+      end
     end
-  end
 
-  @impl true
-  def dump(nil, _, _), do: {:ok, nil}
+    @impl true
+    def dump(nil, _, _), do: {:ok, nil}
 
-  def dump(slug, _dumper, params) do
-    case extract_uuid(slug, params) do
-      {:ok, _scope, uuid} -> {:ok, uuid}
-      :error -> :error
+    def dump(slug, _dumper, params) do
+      case extract_uuid(slug, params) do
+        {:ok, _scope, uuid} -> {:ok, uuid}
+        :error -> :error
+      end
     end
-  end
 
-  @impl true
-  def autogenerate(params) do
-    params.uuid_config
-    |> Uniq.UUID.autogenerate()
-    |> add_scope(params)
-  end
-
-  @spec generate(module, field :: atom) ::
-          {:ok, scoped_uuid :: String.t()} | {:error, reason :: String.t()}
-  @doc "Generates an ID for a schema module and field, by default the id field"
-  def generate(module, field \\ :id) do
-    try do
-      {:parameterized, {Uniq.ScopedUUID, params}} =
-        Map.get(module.__changeset__(), field)
-
-      {:ok, autogenerate(params)}
-    rescue
-      _ ->
-        {:error, "Can only generate IDs for ScopedUUID fields"}
+    @impl true
+    def autogenerate(params) do
+      params.uuid_config
+      |> Uniq.UUID.autogenerate()
+      |> add_scope(params)
     end
-  end
 
-  @impl true
-  def embed_as(format, params), do: Uniq.UUID.embed_as(format, params.uuid_config)
+    @spec generate(module, field :: atom) ::
+            {:ok, scoped_uuid :: String.t()} | {:error, reason :: String.t()}
+    @doc "Generates an ID for a schema module and field, by default the id field"
+    def generate(module, field \\ :id) do
+      try do
+        {:parameterized, {Uniq.ScopedUUID, params}} =
+          Map.get(module.__changeset__(), field)
 
-  @impl true
-  def equal?(nil, nil, _params), do: true
-  def equal?(nil, _b, _params), do: false
-  def equal?(_a, nil, _params), do: false
+        {:ok, autogenerate(params)}
+      rescue
+        _ ->
+          {:error, "Can only generate IDs for ScopedUUID fields"}
+      end
+    end
 
-  def equal?(a, b, params) do
-    with {:ok, scope, uuid_a} <- extract_uuid(a, params),
-         {:ok, ^scope, uuid_b} <- extract_uuid(b, params) do
-      Uniq.UUID.equal?(uuid_a, uuid_b, params.uuid_config)
-    else
-      _ -> Uniq.UUID.equal?(a, b, params.uuid_config)
+    @impl true
+    def embed_as(format, params), do: Uniq.UUID.embed_as(format, params.uuid_config)
+
+    @impl true
+    def equal?(nil, nil, _params), do: true
+    def equal?(nil, _b, _params), do: false
+    def equal?(_a, nil, _params), do: false
+
+    def equal?(a, b, params) do
+      with {:ok, scope, uuid_a} <- extract_uuid(a, params),
+           {:ok, ^scope, uuid_b} <- extract_uuid(b, params) do
+        Uniq.UUID.equal?(uuid_a, uuid_b, params.uuid_config)
+      else
+        _ -> Uniq.UUID.equal?(a, b, params.uuid_config)
+      end
     end
   end
 

--- a/lib/scoped_uuid.ex
+++ b/lib/scoped_uuid.ex
@@ -1,0 +1,178 @@
+defmodule Uniq.ScopedUUID do
+  @doc """
+  Generates and validates UUIDs in Ecto schemas which are scoped using a prefix.
+
+  With scoped UUIDs, applications can differentiate between UUIDs that are generated
+  by and intended for use in different parts of the application, preventing
+  their use in other scopes.
+
+  It also makes it easy to determine the intended use of an ID in error logs,
+  in client code, etc.
+
+  The scope is included in the Ecto field defintion, and is prepended to the UUID
+  which is separated from the ID itself by an `_`. The UUID itself is rendered
+  as a slug making it easy to use outside the application, e.g.: `account_AYilFryMfFqbaBJlH1WLng`.
+
+  Only the UUID itself is stored in the Ecto store itself as a standard binary
+  ID, with the scope used for validation in the application.
+
+  Foreign keys in schemas that use a `belongs_to` will automatically use the
+  correct scoping as well.
+
+  When defining a ScopedUUID field, the following options are supported:
+
+    * scope: String.t(), required. Can not require underscores.
+    * version: integer, defaults to 7. The version of UUIDs to generate.
+
+  ## Examples
+
+      @primary_key {:id, Uniq.ScopedUUID, scope: "user", autogenerate: true}
+      @foreign_key_type Uniq.ScopedUUID
+
+      schema "locations" do
+        field(:external_id, Uniq.ScopedUUID, scope: "placeext")
+        belongs_to(:region, MyApp.Region) # automatically scoped!
+      end
+
+  """
+  use Ecto.ParameterizedType
+
+  @impl true
+  def init(opts) do
+    schema = Keyword.fetch!(opts, :schema)
+    field = Keyword.fetch!(opts, :field)
+    version = Keyword.get(opts, :uuid_version, 7)
+
+    uuid_config =
+      Uniq.UUID.init(
+        schema: schema,
+        field: field,
+        version: version,
+        format: :slug,
+        default: :raw,
+        dump: :raw
+      )
+
+    foreign_key? = Keyword.get(opts, :foreign_key) != nil
+
+    if foreign_key? do
+      %{
+        schema: schema,
+        field: field,
+        uuid_config: uuid_config
+      }
+    else
+      scope = Keyword.get(opts, :scope) || raise "`:scope` option is required"
+
+      if String.contains?(scope, "_") do
+        raise "ScopedUUID scopes may not contain underscores."
+      end
+
+      %{
+        scope: scope,
+        uuid_config: uuid_config
+      }
+    end
+  end
+
+  @impl true
+  def type(_params), do: :uuid
+
+  @impl true
+  def cast(nil, _params), do: {:ok, nil}
+
+  def cast(data, params) do
+    scope = scope_for(params)
+
+    case extract_uuid(data, params) do
+      {:ok, ^scope, _uuid} -> {:ok, data}
+      _error -> :error
+    end
+  end
+
+  @impl true
+  def load(data, loader, params) do
+    case Uniq.UUID.load(data, loader, params.uuid_config) do
+      {:ok, nil} -> {:ok, nil}
+      {:ok, uuid} -> {:ok, add_scope(uuid, params)}
+      :error -> :error
+    end
+  end
+
+  @impl true
+  def dump(nil, _, _), do: {:ok, nil}
+
+  def dump(slug, _dumper, params) do
+    case extract_uuid(slug, params) do
+      {:ok, _scope, uuid} -> {:ok, uuid}
+      :error -> :error
+    end
+  end
+
+  @impl true
+  def autogenerate(params) do
+    params.uuid_config
+    |> Uniq.UUID.autogenerate()
+    |> add_scope(params)
+  end
+
+  @spec generate(module, field :: atom) ::
+          {:ok, scoped_uuid :: String.t()} | {:error, reason :: String.t()}
+  @doc "Generates an ID for a schema module and field, by default the id field"
+  def generate(module, field \\ :id) do
+    try do
+      {:parameterized, {Uniq.ScopedUUID, params}} =
+        Map.get(module.__changeset__(), field)
+
+      {:ok, autogenerate(params)}
+    rescue
+      _ ->
+        {:error, "Can only generate IDs for ScopedUUID fields"}
+    end
+  end
+
+  @impl true
+  def embed_as(format, params), do: Uniq.UUID.embed_as(format, params.uuid_config)
+
+  @impl true
+  def equal?(nil, nil, _params), do: true
+  def equal?(nil, _b, _params), do: false
+  def equal?(_a, nil, _params), do: false
+
+  def equal?(a, b, params) do
+    with {:ok, scope, uuid_a} <- extract_uuid(a, params),
+         {:ok, ^scope, uuid_b} <- extract_uuid(b, params) do
+      Uniq.UUID.equal?(uuid_a, uuid_b, params.uuid_config)
+    else
+      _ -> Uniq.UUID.equal?(a, b, params.uuid_config)
+    end
+  end
+
+  defp scope_for(%{scope: scope}), do: scope
+
+  # When dealing with a belongs_to assocation, fetch the scope from
+  # the associations schema module
+  defp scope_for(%{schema: schema, field: field}) do
+    %{related: schema, related_key: field} = schema.__schema__(:association, field)
+    {:parameterized, {__MODULE__, %{scope: scope}}} = schema.__schema__(:type, field)
+    scope
+  end
+
+  defp add_scope(uuid, params) do
+    scope = scope_for(params)
+    "#{scope}_#{uuid}"
+  end
+
+  defp fake_dumper(_type, value), do: value
+
+  defp extract_uuid(scoped_uuid, params) do
+    scope = scope_for(params)
+
+    with <<^scope::binary, ?_, slug::binary>> <- scoped_uuid,
+         {:ok, uuid} <- Uniq.UUID.dump(slug, &fake_dumper/2, params.uuid_config) do
+      {:ok, scope, uuid}
+    else
+      _ -> :error
+    end
+  end
+end

--- a/test/scoped_uuid_test.exs
+++ b/test/scoped_uuid_test.exs
@@ -1,0 +1,122 @@
+defmodule Uniq.ScopedUUIDTest do
+  use ExUnit.Case, async: true
+
+  alias Uniq.ScopedUUID
+  alias Uniq.UUID
+
+  defmodule TestSchema do
+    use Ecto.Schema
+
+    @primary_key {:id, ScopedUUID, scope: "test", autogenerate: true}
+    @foreign_key_type ScopedUUID
+
+    schema "test" do
+      belongs_to(:test, TestSchema)
+    end
+  end
+
+  defmodule UUID4Schema do
+    use Ecto.Schema
+
+    @primary_key {:id, ScopedUUID, scope: "version", autogenerate: true, uuid_version: 4}
+    @foreign_key_type ScopedUUID
+
+    schema "test" do
+      belongs_to(:test, TestSchema)
+    end
+  end
+
+  @params ScopedUUID.init(
+            schema: TestSchema,
+            field: :id,
+            primary_key: true,
+            autogenerate: true,
+            scope: "test"
+          )
+  @belongs_to_params ScopedUUID.init(schema: TestSchema, field: :test, foreign_key: :test_id)
+  @loader nil
+  @dumper nil
+
+  @test_prefixed_uuid "test_cjKzffwTRMCOG5paB-JJIQ"
+  @test_uuid UUID.to_string("7232b37d-fc13-44c0-8e1b-9a5a07e24921", :raw)
+  @test_prefixed_uuid_with_leading_zero "test_AYilFryMfFqbaBJlH1WLng"
+  @test_uuid_with_leading_zero UUID.to_string("0188a516-bc8c-7c5a-9b68-12651f558b9e", :raw)
+  @test_prefixed_uuid_null "test_AAAAAAAAAAAAAAAAAAAAAA"
+  @test_uuid_null UUID.to_string("00000000-0000-0000-0000-000000000000", :raw)
+  @test_prefixed_uuid_invalid_characters "test_" <> String.duplicate(".", 32)
+  @test_uuid_invalid_characters String.duplicate(".", 22)
+  @test_prefixed_uuid_invalid_format "test_" <> String.duplicate("x", 31)
+  @test_uuid_invalid_format String.duplicate("x", 21)
+
+  test "requires a scope" do
+    assert_raise RuntimeError, fn -> ScopedUUID.init(schema: "test", field: :test, version: 7) end
+  end
+
+  test "scopes can not include underscores" do
+    assert_raise RuntimeError, fn ->
+      ScopedUUID.init(schema: "test_foo", field: :test, version: 7)
+    end
+  end
+
+  test "UUID version is configurable" do
+    {:ok, id} = ScopedUUID.generate(TestSchema)
+    [_, uuid] = String.split(id, "_", parts: 2)
+    assert UUID.info!(uuid).version == 7
+
+    {:ok, id} = ScopedUUID.generate(UUID4Schema, :id)
+    [_, uuid] = String.split(id, "_", parts: 2)
+    assert UUID.info!(uuid).version == 4
+  end
+
+  test "cast/2" do
+    assert ScopedUUID.cast(@test_prefixed_uuid, @params) == {:ok, @test_prefixed_uuid}
+
+    assert ScopedUUID.cast(@test_prefixed_uuid_with_leading_zero, @params) ==
+             {:ok, @test_prefixed_uuid_with_leading_zero}
+
+    assert ScopedUUID.cast(@test_prefixed_uuid_null, @params) == {:ok, @test_prefixed_uuid_null}
+    assert ScopedUUID.cast(nil, @params) == {:ok, nil}
+    assert ScopedUUID.cast("otherprefix" <> @test_prefixed_uuid, @params) == :error
+    assert ScopedUUID.cast(@test_prefixed_uuid_invalid_characters, @params) == :error
+    assert ScopedUUID.cast(@test_prefixed_uuid_invalid_format, @params) == :error
+
+    assert ScopedUUID.cast(@test_prefixed_uuid, @belongs_to_params) ==
+             {:ok, @test_prefixed_uuid}
+  end
+
+  test "load/3" do
+    assert ScopedUUID.load(@test_uuid, @loader, @params) == {:ok, @test_prefixed_uuid}
+
+    assert ScopedUUID.load(@test_uuid_with_leading_zero, @loader, @params) ==
+             {:ok, @test_prefixed_uuid_with_leading_zero}
+
+    assert ScopedUUID.load(@test_uuid_null, @loader, @params) == {:ok, @test_prefixed_uuid_null}
+    assert ScopedUUID.load(@test_uuid_invalid_characters, @loader, @params) == :error
+    assert ScopedUUID.load(@test_uuid_invalid_format, @loader, @params) == :error
+    assert ScopedUUID.load(@test_prefixed_uuid, @loader, @params) == :error
+    assert ScopedUUID.load(nil, @loader, @params) == {:ok, nil}
+
+    assert ScopedUUID.load(@test_uuid, @loader, @belongs_to_params) ==
+             {:ok, @test_prefixed_uuid}
+  end
+
+  test "dump/3" do
+    assert ScopedUUID.dump(@test_prefixed_uuid, @dumper, @params) == {:ok, @test_uuid}
+
+    assert ScopedUUID.dump(@test_prefixed_uuid_with_leading_zero, @dumper, @params) ==
+             {:ok, @test_uuid_with_leading_zero}
+
+    assert ScopedUUID.dump(@test_prefixed_uuid_null, @dumper, @params) == {:ok, @test_uuid_null}
+    assert ScopedUUID.dump(@test_uuid, @dumper, @params) == :error
+    assert ScopedUUID.dump(nil, @dumper, @params) == {:ok, nil}
+
+    assert ScopedUUID.dump(@test_prefixed_uuid, @dumper, @belongs_to_params) ==
+             {:ok, @test_uuid}
+  end
+
+  test "autogenerate/1" do
+    assert prefixed_uuid = ScopedUUID.autogenerate(@params)
+    assert {:ok, uuid} = ScopedUUID.dump(prefixed_uuid, nil, @params)
+    assert {:ok, %UUID{format: :raw, version: 7}} = UUID.parse(uuid)
+  end
+end

--- a/test/support/test_repo.exs
+++ b/test/support/test_repo.exs
@@ -48,6 +48,9 @@ defmodule Ecto.TestAdapter do
   def autogenerate(:binary_id), do: Ecto.UUID.bingenerate()
 
   ## Queryable
+  def delete(_adapter_meta, _schema_meta, _filters, _returning, _options) do
+    {:ok, []}
+  end
 
   def prepare(operation, query), do: {:nocache, {operation, query}}
 


### PR DESCRIPTION
I am using this implementation of scoped UUIDs which are UUIDs that have a prefixed scope (e.g. "user" or "account"), allowing their intended purposed to identified,  to be pattern-matched, and more easily tracked in logging/telemetry messages.

They are still stored in the Ecto store as regular UUIDs, but appear in the application with their scope prefixed.

Such prefixed UUIDs are used in various APIs around the internet, e.g. Stripe's APIs.

This implementation allows configuration of the UUID version in use, and provides a convenience function to generate IDs for a given schema / field.

I was considering creating a new library just for this, but it occurred to me that this really fits the scope of Uniq well and is such a small implementation which depends so deeply on Uniq itself that it felt like it would make sense to add it to Uniq directly.

Feedback and thoughts on all of the above welcome :)