### PR TITLE
Fix Elixir 1.20 bitstring variable pin warnings

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -544,9 +544,9 @@ defmodule Uniq.UUID do
              <<time::64>>,
            <<timestamp::uint(60)>> <-
              <<time_hi::bits(12), time_mid::bits(16), time_lo::bits(32)>>,
-           <<clock_hi::bits(clock_hi_size), clock_lo::bits(8), node::bits(48)>> <-
+           <<clock_hi::bits(^clock_hi_size), clock_lo::bits(8), node::bits(48)>> <-
              rest,
-           <<clock::uint(clock_size)>> <-
+           <<clock::uint(^clock_size)>> <-
              <<clock_hi::bits(clock_hi_size), clock_lo::bits(8)>> do
         {:ok,
          %{

--- a/mix.exs
+++ b/mix.exs
@@ -12,11 +12,6 @@ defmodule Uniq.MixProject do
       deps: deps(),
       aliases: aliases(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      preferred_cli_env: [
-        bench: :bench,
-        docs: :docs,
-        "hex.publish": :docs
-      ],
       name: "Uniq",
       source_url: "https://github.com/bitwalker/uniq",
       homepage_url: "http://github.com/bitwalker/uniq",
@@ -31,6 +26,14 @@ defmodule Uniq.MixProject do
           {:"LICENSE.md", [title: "License"]}
         ]
       ]
+    ]
+  end
+
+  def cli do
+    [
+      bench: :bench,
+      docs: :docs,
+      "hex.publish": :docs
     ]
   end
 


### PR DESCRIPTION
Add ^ pin operator before bitstring size variables to resolve Elixir 1.20 compilation warnings.